### PR TITLE
Calling -[super layoutSubviews]

### DIFF
--- a/ANBlurredImageView/ANBlurredImageView.m
+++ b/ANBlurredImageView/ANBlurredImageView.m
@@ -20,6 +20,8 @@
 }
 
 -(void)layoutSubviews{
+    [super layoutSubviews];
+    
     _baseImage = self.image;
     [self generateBlurFramesWithCompletion:^{}];
     


### PR DESCRIPTION
UIView subclasses must always call `[super layoutSubviews]` when overriding.
