### PR TITLE
generate blur frames only once on addSubview:

### DIFF
--- a/ANBlurredImageView/ANBlurredImageView.m
+++ b/ANBlurredImageView/ANBlurredImageView.m
@@ -19,15 +19,17 @@
     return self;
 }
 
--(void)layoutSubviews{
-    [super layoutSubviews];
+- (void)willMoveToSuperview:(UIView *)newSuperview {
+    [super willMoveToSuperview:newSuperview];
     
-    _baseImage = self.image;
-    [self generateBlurFramesWithCompletion:^{}];
-    
-    // Defaults
-    self.animationDuration = 0.1f;
-    self.animationRepeatCount = 1;
+    if (newSuperview) {
+        _baseImage = self.image;
+        [self generateBlurFramesWithCompletion:^{}];
+        
+        // Defaults
+        self.animationDuration = 0.1f;
+        self.animationRepeatCount = 1;
+    }
 }
 
 // Downsamples the image so we avoid needing to blur a huge image.


### PR DESCRIPTION
This PR fixes issue when blur frames re-generates every time on setting `frame` to `ANBlurredImageView` instance. For example, in UIKit animations:

``` obj-c
ANBlurredImageView *blurredImageView = <...>;
[self addSubview:blurredImageView]; // from now, frames generates here

// ...

blurredImageView.frame = <...>; // does not call expensive generateBlurFramesWithCompletion:

[UIView animateWithDuration:0.25 animations:^{
    blurredImageView.frame = <...>;
}];
```
